### PR TITLE
No need to require `version`

### DIFF
--- a/lib/opsworks_wrapper.rb
+++ b/lib/opsworks_wrapper.rb
@@ -1,5 +1,3 @@
-require "opsworks_wrapper/version"
-
 module OpsworksWrapper
   class Deployer
     require 'aws-sdk'


### PR DESCRIPTION
This is a non-existent file and it will cause problems
